### PR TITLE
fix(): fix for npm3

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 // Inspired by: https://github.com/commitizen/cz-conventional-changelog and https://github.com/commitizen/cz-cli
 
-var wrap = require('./node_modules/word-wrap/index');
+var wrap = require('word-wrap');
 var SYMLINK_CONFIG_NAME = 'cz-config';
 var log = require('winston');
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "version": "2.3.4",
   "name": "cz-customizable",
   "description": "Commitizen customizable adapter following the conventional-changelog format.",
   "main": "index.js",


### PR DESCRIPTION
npm3 uses dedup and word-warp is not in the node_modules dir from __dirname