### PR TITLE
feat: add inquirer as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Suitable for large teams working with multiple projects with their own commit sc
 
 
 ## Steps:
-* install commitizen in case you don't have it: `npm install -g commitizen`. Make sure you have version `2.8.1`+.
+* install commitizen in case you don't have it: `npm install -g commitizen`. Make sure you have the latest version of commitizen installed globally.
 * install the cz-customizable: `npm install cz-customizable --save-dev`
 * configure `commitizen` to use `cz-customizable` as plugin. Add those lines to your `package.json`:
 
@@ -27,7 +27,7 @@ Suitable for large teams working with multiple projects with their own commit sc
   ```
 
 ## You have two options to configure `cz-customizable`:
-* Option 1: Config block in your `package.json` (recommended):
+* Config block in your `package.json`:
   ```
   ...
   "config": {
@@ -40,10 +40,6 @@ Suitable for large teams working with multiple projects with their own commit sc
   }
   ```
 Note: option one allows you to have your config away from root directory. It also gives you a change to define any name to your `cz-config.js`.
-
-* Option 2: (**DEPRECATED** in order to align configuration with Commitizen. Please use option 1)
-Run `cp ./node_modules/cz-customizable/cz-config-EXAMPLE.js ./.cz-config.js` in a project root directory to get a template.
-Note: if you chose option 2, config file has to be called `.cz-config.js`. This option will be removed after the next major release.
 
 
 **Notes:**

--- a/index.js
+++ b/index.js
@@ -24,17 +24,8 @@ function readConfigFile() {
 
       console.info('>>> Using cz-customizable config specified in your package.json: ', pkgPath);
 
-      config = require(pkgPath);
-      return config;
+      return require(pkgPath);
     }
-  }
-
-  // Second attempt is the nearest .cz-config.js.
-  var config = findConfig.require(CZ_CONFIG_NAME, {home: false});
-
-  if (config) {
-    console.info('>>> cz-customizable config file has been found.');
-    return config;
   }
 
   log.warn('Unable to find a configuration file. Please refer to documentation to learn how to ser up: https://github.com/leonardoanalista/cz-customizable#steps "');

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
     "find-config": "0.3.0",
     "temp": "0.8.3",
     "winston": "2.1.0",
-    "word-wrap": "1.1.0"
+    "word-wrap": "1.1.0",
+    "inquirer": "1.2.3"
   },
   "devDependencies": {
     "codecov.io": "0.1.6",
-    "commitizen": "2.8.1",
+    "commitizen": "2.9.5",
     "eslint": "1.9.0",
     "ghooks": "1.0.0",
     "istanbul": "0.4.0",


### PR DESCRIPTION
feat: add inquirer as dependency

Upgraded commitizen to the latest.

BREAKING CHANGE:
please reinstall the latest 2.9.5 commitizen globally via npm -i commitizen. Deprecated
configuration option has been removed.

ISSUES CLOSED: #34