### PR TITLE
improve config discovery with defaults and allow message overides

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Suitable for large teams working with multiple projects with their own commit sc
   ```
 
 ## Configure
-* Config block in your `package.json`:
+* `cz-customizable` will first look for a file called `.cz-config.js`
+* alternatively add a config block in your `package.json`:
   ```
   ...
   "config": {
@@ -44,7 +45,7 @@ Note: option one allows you to have your config away from root directory. It als
 
 From now on, instead of `git commit` you type `git cz` and let the tool do the work for you.
 
-Hopefully this will help you to have consistent commit messages and have a fully automated deployemnt without any human intervention.
+Hopefully this will help you to have consistent commit messages and have a fully automated deployment without any human intervention.
 
 ## Options
 

--- a/cz-config-EXAMPLE.js
+++ b/cz-config-EXAMPLE.js
@@ -18,7 +18,7 @@ module.exports = {
   scopes: [
     {name: 'accounts'},
     {name: 'admin'},
-    {name: 'exampleScope'},    
+    {name: 'exampleScope'},
     {name: 'changeMe'}
   ],
 
@@ -34,6 +34,18 @@ module.exports = {
     ]
   },
   */
+  // override the messages, defaults are as follows
+  messages: {
+    type: 'Select the type of change that you\'re committing:',
+    scope: '\nDenote the SCOPE of this change (optional):',
+    // used if allowCustomScopes is true
+    customScope: 'Denote the SCOPE of this change:',
+    subject: 'Write a SHORT, IMPERATIVE tense description of the change:\n',
+    body: 'Provide a LONGER description of the change (optional). Use "|" to break new line:\n',
+    breaking: 'List any BREAKING CHANGES (optional):\n',
+    footer: 'List any ISSUES CLOSED by this change (optional). E.g.: #31, #34:\n',
+    confirmCommit: 'Are you sure you want to proceed with the commit above?'
+  },
 
   allowCustomScopes: true,
   allowBreakingChanges: ['feat', 'fix']

--- a/index.js
+++ b/index.js
@@ -16,11 +16,21 @@ var buildCommit = require('./buildCommit');
 /* istanbul ignore next */
 function readConfigFile() {
 
-  // First try to find config block in the nearest package.json
-  var pkg = findConfig.require('package.json', {home: false});
+  // First try to find the .cz-config.js config file
+  var czConfig = findConfig.require(CZ_CONFIG_NAME, {home: false});
+  if (czConfig) {
+    return czConfig;
+  }
+
+  // fallback to locating it using the config block in the nearest package.json
+  var pkg = findConfig('package.json', {home: false});
   if (pkg) {
+    var pkgDir = path.dirname(pkg);
+    pkg = require(pkg);
+
     if (pkg.config && pkg.config['cz-customizable'] && pkg.config['cz-customizable'].config) {
-      var pkgPath = path.resolve(pkg.config['cz-customizable'].config);
+      // resolve relative to discovered package.json
+      var pkgPath = path.resolve(pkgDir, pkg.config['cz-customizable'].config);
 
       console.info('>>> Using cz-customizable config specified in your package.json: ', pkgPath);
 

--- a/questions.js
+++ b/questions.js
@@ -14,23 +14,33 @@ module.exports = {
   getQuestions: function(config, cz) {
 
     // normalize config optional options
-    config.scopeOverrides = config.scopeOverrides || {};
+    var scopeOverrides = config.scopeOverrides || {};
+    var messages = config.messages || {};
+
+    messages.type = messages.type || 'Select the type of change that you\'re committing:';
+    messages.scope = messages.scope || '\nDenote the SCOPE of this change (optional):';
+    messages.customScope = messages.customScope || 'Denote the SCOPE of this change:';
+    messages.subject = messages.subject || 'Write a SHORT, IMPERATIVE tense description of the change:\n';
+    messages.body = messages.body || 'Provide a LONGER description of the change (optional). Use "|" to break new line:\n';
+    messages.breaking = messages.breaking || 'List any BREAKING CHANGES (optional):\n';
+    messages.footer = messages.footer || 'List any ISSUES CLOSED by this change (optional). E.g.: #31, #34:\n';
+    messages.confirmCommit = messages.confirmCommit || 'Are you sure you want to proceed with the commit above?';
 
     var questions = [
       {
         type: 'list',
         name: 'type',
-        message: 'Select the type of change that you\'re committing:',
+        message: messages.type,
         choices: config.types
       },
       {
         type: 'list',
         name: 'scope',
-        message: '\nDenote the SCOPE of this change (optional):',
+        message: messages.scope,
         choices: function(answers) {
           var scopes = [];
-          if (config.scopeOverrides[answers.type]) {
-            scopes = scopes.concat(config.scopeOverrides[answers.type]);
+          if (scopeOverrides[answers.type]) {
+            scopes = scopes.concat(scopeOverrides[answers.type]);
           } else {
             scopes = scopes.concat(config.scopes);
           }
@@ -45,8 +55,8 @@ module.exports = {
         },
         when: function(answers) {
           var hasScope = false;
-          if (config.scopeOverrides[answers.type]) {
-            hasScope = !!(config.scopeOverrides[answers.type].length > 0);
+          if (scopeOverrides[answers.type]) {
+            hasScope = !!(scopeOverrides[answers.type].length > 0);
           } else {
             hasScope = !!(config.scopes && (config.scopes.length > 0));
           }
@@ -61,7 +71,7 @@ module.exports = {
       {
         type: 'input',
         name: 'scope',
-        message: 'Denote the SCOPE of this change:',
+        message: messages.customScope,
         when: function(answers) {
           return answers.scope === 'custom';
         }
@@ -69,7 +79,7 @@ module.exports = {
       {
         type: 'input',
         name: 'subject',
-        message: 'Write a SHORT, IMPERATIVE tense description of the change:\n',
+        message: messages.subject,
         validate: function(value) {
           return !!value;
         },
@@ -80,12 +90,12 @@ module.exports = {
       {
         type: 'input',
         name: 'body',
-        message: 'Provide a LONGER description of the change (optional). Use "|" to break new line:\n'
+        message: messages.body
       },
       {
         type: 'input',
         name: 'breaking',
-        message: 'List any BREAKING CHANGES (optional):\n',
+        message: messages.breaking,
         when: function(answers) {
           if (config.allowBreakingChanges && config.allowBreakingChanges.indexOf(answers.type.toLowerCase()) >= 0) {
             return true;
@@ -96,7 +106,7 @@ module.exports = {
       {
         type: 'input',
         name: 'footer',
-        message: 'List any ISSUES CLOSED by this change (optional). E.g.: #31, #34:\n',
+        message: messages.footer,
         when: isNotWip
       },
       {
@@ -110,7 +120,7 @@ module.exports = {
         message: function(answers) {
           var SEP = '###--------------------------------------------------------###';
           log.info('\n' + SEP + '\n' + buildCommit(answers) + '\n' + SEP + '\n');
-          return 'Are you sure you want to proceed with the commit above?';
+          return messages.confirmCommit;
         }
       }
     ];


### PR DESCRIPTION
For my use case (a [lerna](https://www.npmjs.com/package/lerna) based monorepo) quite often I could be committing inside a package with a `package.json`. Which wouldn't have the `cz-customizable` config in. So I've added the ability to use a predefined name for the config file, resolved using `find-config` and added message overrides.