### PR TITLE
feat(config): configurable commit block prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Here are the options you can set in your `.cz-config.js`:
   * allowCustomScopes: {boolean, default false}: adds the option `custom` to scope selection so you can still typea scope if you need.
   * allowBreakingChanges: {Array of Strings: default none}. List of commit types you would like to the question `breaking change` prompted. Eg.: ['feat', 'fix']
   * appendBranchNameToCommitMessage: If you use `cz-customizable` with `cz-customizable-ghooks`, you can get the branch name automatically appended to the commit message. This is done by a commit hook on `cz-customizable-ghooks`. This option has been added on `cz-customizable-ghooks`, v1.3.0. Default value is `true`.
+  * breakingPrefix: {string, default 'BREAKING CHANGE:'}: Set a custom prefix for the breaking change block in commit messages
+  * footerPrefix: {string, default 'ISSUES CLOSED:'}: Set a custom prefix for the footer block in commit messages
 
 ## Related tools
 - (https://github.com/commitizen/cz-cli)

--- a/buildCommit.js
+++ b/buildCommit.js
@@ -4,7 +4,7 @@
 var wrap = require('word-wrap');
 
 
-module.exports = function buildCommit(answers) {
+module.exports = function buildCommit(answers, config) {
 
   var maxLineWidth = 100;
 
@@ -52,10 +52,12 @@ module.exports = function buildCommit(answers) {
     result += '\n\n' + body;
   }
   if (breaking) {
-    result += '\n\n' + 'BREAKING CHANGE:\n' + breaking;
+    var breakingPrefix = config.breakingPrefix || 'BREAKING CHANGE:';
+    result += '\n\n' + breakingPrefix + '\n' + breaking;
   }
   if (footer) {
-    result += '\n\nISSUES CLOSED: ' + footer;
+    var footerPrefix = config.footerPrefix || 'ISSUES CLOSED:';
+    result += '\n\n' + footerPrefix + ' ' + footer;
   }
 
   return escapeSpecialChars(result);

--- a/index.js
+++ b/index.js
@@ -47,21 +47,21 @@ module.exports = {
         temp.open(null, function(err, info) {
           /* istanbul ignore else */
           if (!err) {
-            fs.write(info.fd, buildCommit(answers));
+            fs.write(info.fd, buildCommit(answers, config));
             fs.close(info.fd, function(err) {
               editor(info.path, function (code, sig) {
                 if (code === 0) {
                   var commitStr = fs.readFileSync(info.path, { encoding: 'utf8' });
                   commit(commitStr);
                 } else {
-                  log.info('Editor returned non zero value. Commit message was:\n' + buildCommit(answers));
+                  log.info('Editor returned non zero value. Commit message was:\n' + buildCommit(answers, config));
                 }
               });
             });
           }
         });
       } else if (answers.confirmCommit === 'yes') {
-        commit(buildCommit(answers));
+        commit(buildCommit(answers, config));
       } else {
         log.info('Commit has been canceled.');
       }

--- a/questions.js
+++ b/questions.js
@@ -119,7 +119,7 @@ module.exports = {
         ],
         message: function(answers) {
           var SEP = '###--------------------------------------------------------###';
-          log.info('\n' + SEP + '\n' + buildCommit(answers) + '\n' + SEP + '\n');
+          log.info('\n' + SEP + '\n' + buildCommit(answers, config) + '\n' + SEP + '\n');
           return messages.confirmCommit;
         }
       }

--- a/spec/czCustomizableSpec.js
+++ b/spec/czCustomizableSpec.js
@@ -192,4 +192,76 @@ describe('cz-customizable', function() {
 
   });
 
+  it('should call commit() function with custom breaking prefix', function() {
+    var answers = {
+      confirmCommit: 'yes',
+      type: 'feat',
+      scope: 'myScope',
+      subject: 'create a new cool feature',
+      breaking: 'breaking',
+      footer: 'my footer'
+    };
+    
+    module.__set__({
+      // it mocks winston logging tool
+      log: {
+        info: function() {}
+      },
+
+      readConfigFile: function() {
+        return {
+          types: [{value: 'feat', name: 'feat: my feat'}],
+          scopes: [{name: 'myScope'}],
+          scopeOverrides: {
+            fix: [{name: 'fixOverride'}]
+          },
+          allowCustomScopes: true,
+          allowBreakingChanges: ['feat'],
+          breakingPrefix: 'WARNING:'
+        };
+      }
+    });
+
+    var mockCz = getMockedCz(answers);
+    module.prompter(mockCz, commit);
+
+    expect(commit).toHaveBeenCalledWith('feat(myScope): create a new cool feature\n\nWARNING:\nbreaking\n\nISSUES CLOSED: my footer');
+  });
+
+  it('should call commit() function with custom footer prefix', function() {
+    var answers = {
+      confirmCommit: 'yes',
+      type: 'feat',
+      scope: 'myScope',
+      subject: 'create a new cool feature',
+      breaking: 'breaking',
+      footer: 'my footer'
+    };
+    
+    module.__set__({
+      // it mocks winston logging tool
+      log: {
+        info: function() {}
+      },
+
+      readConfigFile: function() {
+        return {
+          types: [{value: 'feat', name: 'feat: my feat'}],
+          scopes: [{name: 'myScope'}],
+          scopeOverrides: {
+            fix: [{name: 'fixOverride'}]
+          },
+          allowCustomScopes: true,
+          allowBreakingChanges: ['feat'],
+          footerPrefix: 'FIXES:'
+        };
+      }
+    });
+
+    var mockCz = getMockedCz(answers);
+    module.prompter(mockCz, commit);
+    
+    expect(commit).toHaveBeenCalledWith('feat(myScope): create a new cool feature\n\nBREAKING CHANGE:\nbreaking\n\nFIXES: my footer');
+  });
+
 });


### PR DESCRIPTION
Add config options for commit message block prefixes. Set ‘BREAKING CHANGE:’ and ‘ISSUES CLOSED:’ as the default.