### PR TITLE
feat: able to customize length limit of subject and warn when exceed

### DIFF
--- a/cz-config-EXAMPLE.js
+++ b/cz-config-EXAMPLE.js
@@ -48,6 +48,9 @@ module.exports = {
   },
 
   allowCustomScopes: true,
-  allowBreakingChanges: ['feat', 'fix']
+  allowBreakingChanges: ['feat', 'fix'],
+
+  // limit subject length
+  subjectLimit: 100
 
 };

--- a/index.js
+++ b/index.js
@@ -46,8 +46,9 @@ module.exports = {
 
   prompter: function(cz, commit) {
     var config = readConfigFile();
+    var subjectLimit = config.subjectLimit || 100;
 
-    log.info('\n\nLine 1 will be cropped at 100 characters. All other lines will be wrapped after 100 characters.\n');
+    log.info('\n\nLine 1 will be cropped at ' + subjectLimit + ' characters. All other lines will be wrapped after 100 characters.\n');
 
     var questions = require('./questions').getQuestions(config, cz);
 

--- a/questions.js
+++ b/questions.js
@@ -81,7 +81,11 @@ module.exports = {
         name: 'subject',
         message: messages.subject,
         validate: function(value) {
-          return !!value;
+          var limit = config.subjectLimit || 100;
+          if (value.length > limit) {
+            return 'Exceed limit: ' + limit;
+          }
+          return true;
         },
         filter: function(value) {
           return value.charAt(0).toLowerCase() + value.slice(1);

--- a/spec/questionsSpec.js
+++ b/spec/questionsSpec.js
@@ -25,7 +25,8 @@ describe('cz-customizable', function() {
         fix: [{name: 'fixOverride'}]
       },
       allowCustomScopes: true,
-      allowBreakingChanges: ['feat']
+      allowBreakingChanges: ['feat'],
+      subjectLimit: 20
     };
 
     // question 1 - TYPE
@@ -51,7 +52,8 @@ describe('cz-customizable', function() {
     expect(getQuestion(4).name).toEqual('subject');
     expect(getQuestion(4).type).toEqual('input');
     expect(getQuestion(4).message).toMatch(/IMPERATIVE tense description/);
-    expect(getQuestion(4).validate()).toEqual(false); //mandatory question
+    expect(getQuestion(4).validate('good subject')).toEqual(true);
+    expect(getQuestion(4).validate('bad subject that exceed limit')).toEqual('Exceed limit: 20');
     expect(getQuestion(4).filter('Subject')).toEqual('subject');
 
     // question 5 - BODY
@@ -82,6 +84,14 @@ describe('cz-customizable', function() {
       subject: 'create a new cool feature'
     };
     expect(getQuestion(8).message(answers)).toMatch('Are you sure you want to proceed with the commit above?');
+  });
+
+  it('default length limit of subject should be 100', function() {
+    config = {
+      types: [{value: 'feat', name: 'feat: my feat'}]
+    };
+    expect(getQuestion(4).validate('good subject')).toEqual(true);
+    expect(getQuestion(4).validate('bad subject that exceed limit bad subject that exceed limitbad subject that exceed limit test test test')).toEqual('Exceed limit: 100');
   });
 
 


### PR DESCRIPTION
I think it's better to remind user when their subject message exceed limit and  let them rewrite their subject.