### PR TITLE
feat: add Node v10 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = {
         temp.open(null, function(err, info) {
           /* istanbul ignore else */
           if (!err) {
-            fs.write(info.fd, buildCommit(answers, config));
+            fs.writeSync(info.fd, buildCommit(answers, config));
             fs.close(info.fd, function(err) {
               editor(info.path, function (code, sig) {
                 if (code === 0) {


### PR DESCRIPTION
Attempting to `edit` a commit message via the prompt on Node v8 you'll get a depreaction warning: `(node:22043) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.` In Node v10, this will throw an error ([Deprecation Doc: DEP0013](https://nodejs.org/api/deprecations.html#deprecations_dep0013_fs_asynchronous_function_without_callback)).

This PR removes deprecated call and thus adds Node v10 support.

This addresses: https://github.com/leonardoanalista/cz-customizable/issues/14#issuecomment-366460703