### PR TITLE
feat: add Typescript type definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,27 @@
+declare module "cz-customizable" {
+  export interface Option {
+    name: string;
+    value?: string;
+  }
+  export interface Options {
+    types: Option[];
+    scopes?: Option[];
+    scopeOverrides?: { [type: string]: Option[] };
+    messages?: {
+      type?: string,
+      scope?: string,
+      customScope?: string,
+      subject?: string,
+      body?: string,
+      breaking?: string,
+      footer?: string,
+      confirmCommit?: string,
+    };
+    allowCustomScopes?: boolean;
+    allowBreakingChanges?: string[];
+    appendBranchNameToCommitMessage?: boolean;
+    breakingPrefix?: string;
+    footerPrefix?: string;
+    subjectLimit?: number;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "cz-customizable",
   "description": "Commitizen customizable adapter following the conventional-changelog format.",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "eslint": "node_modules/eslint/bin/eslint.js *.js spec/**.js",
     "test": "node_modules/jasmine-node/bin/jasmine-node spec/",


### PR DESCRIPTION
ISSUES CLOSED: #57 

You can now write your config file in Typescript with type safety. Just import the type as normal: 
`import { Options } from "cz-customizable";`