### PR TITLE
feat: add possibility to set empty footerPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Here are the options you can set in your `.cz-config.js`:
 * **appendBranchNameToCommitMessage**: If you use `cz-customizable` with `cz-customizable-ghooks`, you can get the branch name automatically appended to the commit message. This is done by a commit hook on `cz-customizable-ghooks`. This option has been added on `cz-customizable-ghooks`, v1.3.0. Default value is `true`.
 * **ticketNumberPrefix**: {string, default 'ISSUES CLOSED:'}: Set custom prefix for footer ticker number.
 * **breakingPrefix**: {string, default 'BREAKING CHANGE:'}: Set a custom prefix for the breaking change block in commit messages.
-* **footerPrefix**: {string, default 'ISSUES CLOSED:'}: Set a custom prefix for the footer block in commit messages.
+* **footerPrefix**: {string, default 'ISSUES CLOSED:'}: Set a custom prefix for the footer block in commit messages. Set to empty string to remove prefix.
 
 ## Related tools
 - (https://github.com/commitizen/cz-cli)

--- a/buildCommit.js
+++ b/buildCommit.js
@@ -33,6 +33,13 @@ function addType(type, config) {
   return _.trim(`${prefix}${type}${suffix}`);
 }
 
+function addFooter(footer, config) {
+  if (config && config.footerPrefix === '') return `\n\n${footer}`;
+
+  const footerPrefix = config && config.footerPrefix ? config.footerPrefix : 'ISSUES CLOSED:';
+  return `\n\n${footerPrefix} ${footer}`;
+}
+
 module.exports = function buildCommit(answers, config) {
   const wrapOptions = {
     trim: true,
@@ -80,8 +87,7 @@ module.exports = function buildCommit(answers, config) {
     result += `\n\n${breakingPrefix}\n${breaking}`;
   }
   if (footer) {
-    const footerPrefix = config && config.footerPrefix ? config.footerPrefix : 'ISSUES CLOSED:';
-    result += `\n\n${footerPrefix} ${footer}`;
+    result += addFooter(footer, config);
   }
 
   return escapeSpecialChars(result);

--- a/spec/czCustomizableSpec.js
+++ b/spec/czCustomizableSpec.js
@@ -270,6 +270,44 @@ describe('cz-customizable', () => {
     );
   });
 
+  it('should call commit() function with custom footer prefix set to empty string', () => {
+    const answers = {
+      confirmCommit: 'yes',
+      type: 'feat',
+      scope: 'myScope',
+      subject: 'create a new cool feature',
+      breaking: 'breaking',
+      footer: 'my footer',
+    };
+
+    // eslint-disable-next-line no-underscore-dangle
+    module.__set__({
+      log: {
+        info() {},
+      },
+
+      readConfigFile() {
+        return {
+          types: [{ value: 'feat', name: 'feat: my feat' }],
+          scopes: [{ name: 'myScope' }],
+          scopeOverrides: {
+            fix: [{ name: 'fixOverride' }],
+          },
+          allowCustomScopes: true,
+          allowBreakingChanges: ['feat'],
+          footerPrefix: '',
+        };
+      },
+    });
+
+    const mockCz = getMockedCz(answers);
+    module.prompter(mockCz, commit);
+
+    expect(commit).toHaveBeenCalledWith(
+      'feat(myScope): create a new cool feature\n\nBREAKING CHANGE:\nbreaking\n\nmy footer'
+    );
+  });
+
   it('should call commit() function with ticket number', () => {
     const answers = {
       confirmCommit: 'yes',


### PR DESCRIPTION
Respect configuration's `{ footerPrefix: '' }` which will produce
```
...commit

${whateverThereIsForFooter}
```

Instead setting default `ISSUES CLOSED` 