### PR TITLE
feat: make entry point executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Suitable for large teams working with multiple projects with their own commit sc
   ```
 
 ## Configure
+
+### Options 1
+Changes to your git repository, file `package.json`.
+
 * `cz-customizable` will first look for a file called `.cz-config.js`
 * alternatively add a config block in your `package.json`:
   ```
@@ -38,6 +42,17 @@ Suitable for large teams working with multiple projects with their own commit sc
   ```
 Note: option one allows you to have your config away from root directory. It also gives you a change to define any name to your `cz-config.js`.
 
+### Options 2
+Standalne - No Changes to your git repository*. This is suitable when your team is not ready to roll `cz-customizable` across all teams but you still would like to use it for your own commits, no matter the project.
+
+Steps:
+* create config file:
+  * create a file called `.cz-config.js` in your git repository root (*Asumptions: you do a global git ignore on `~/.gitignore_global` for `.cz-config.js`). Or;
+  * create a file called `.cz-config.js` your home directory.
+* npm install -g commitizen
+* npm install -g cz-customizable. Make sure you have version `>v5.6.x`
+* create global commitizen config file `.czrc`: `echo '{ "path": "cz-customizable" }' > ~/.czrc`
+* now run: `npx git-cz` or `git cz`.
 
 **Notes:**
 * you should commit your `.cz-config.js` file to your git.

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /* eslint-disable import/no-dynamic-require */
 /* eslint-disable global-require */
 // Inspired by: https://github.com/commitizen/cz-conventional-changelog and https://github.com/commitizen/cz-cli
@@ -15,6 +17,7 @@ const buildCommit = require('./buildCommit');
 function readConfigFile() {
   // First try to find the .cz-config.js config file
   const czConfig = findConfig.require(CZ_CONFIG_NAME, { home: false });
+
   if (czConfig) {
     return czConfig;
   }


### PR DESCRIPTION
Allow and document a second config option:

### Options 1
* as it is today

### Options 2 (new)
Standalne - No Changes to your git repository*. This is suitable when your team is not ready to roll `cz-customizable` across all teams but you still would like to use it for your own commits, no matter the project.

 Steps:
* create config file:
  * create a file called `.cz-config.js` in your git repository root (*Asumptions: you do a global git ignore on `~/.gitignore_global` for `.cz-config.js`). Or;
  * create a file called `.cz-config.js` your home directory.
* npm install -g commitizen
* npm install -g cz-customizable. Make sure you have version `>v5.6.x`
* create global commitizen config file `.czrc`: `echo '{ "path": "cz-customizable" }' > ~/.czrc`
* now run: `npx git-cz` or `git cz`.