### PR TITLE
feat: add options subjectSeparator typePrefix and typeSuffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Hopefully this will help you to have consistent commit messages and have a fully
 
 Here are the options you can set in your `.cz-config.js`:
 
+* **subjectLimit**: {number, default 100}: This is the commit first line. Example: `feat: this is a new feature` or `feat(scopePayments): this is a new feature`
+* **subjectSeparator**: {string, default ': '}: This is the subject separator. Example: `feat: this is a new feature`
+* **typePrefix**: {string, default ''}: This is the commit type prefix. Example: config: `{ typePrefix: '[' }`, result: `[feat: this is a new feature`
+* **typeSuffix**: {string, default ''}: This is the commit type suffix. Example: config: `{ typePrefix: '[', typeSuffix: ']', subjectSeparator: ' ' }`, result: `[feat] this is a new feature`
+
 * **scopes**: {Array of Strings}: Specify the scopes for your particular project. Eg.: for some banking system: ["acccounts", "payments"]. For another travelling application: ["bookings", "search", "profile"]
 * **scopeOverrides**: {Object where key contains a Array of String}: Use this when you want to override scopes for a specific commit type. Example bellow specify scopes when type is `fix`:
   ```
@@ -78,7 +83,6 @@ Here are the options you can set in your `.cz-config.js`:
     ]
   }
   ```
-* **subjectLimit**: {number, default 100}: This is the commit first line.
 * **allowCustomScopes**: {boolean, default false}: adds the option `custom` to scope selection so you can still type a scope if you need.
 * **allowBreakingChanges**: {Array of Strings: default none}. List of commit types you would like to the question `breaking change` prompted. Eg.: ['feat', 'fix'].
 * **skipQuestions**: {Array of Strings: default none}. List of questions you want to skip. Eg.: ['body', 'footer'].

--- a/package-lock.json
+++ b/package-lock.json
@@ -1427,6 +1427,7 @@
       "resolved": "http://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "0.9.x"
       }
@@ -3550,7 +3551,8 @@
       "version": "0.9.1",
       "resolved": "http://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
       "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "home-or-tmp": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "editor": "1.0.0",
     "find-config": "^1.0.0",
     "inquirer": "^6.2.2",
+    "lodash": "^4.17.11",
     "temp": "^0.9.0",
     "word-wrap": "^1.2.3"
   },

--- a/spec/buildCommitSpec.js
+++ b/spec/buildCommitSpec.js
@@ -1,0 +1,65 @@
+const buildCommit = require('../buildCommit');
+
+describe('buildCommit()', () => {
+  const answers = {
+    type: 'feat',
+    scope: 'app',
+    subject: 'this is a new feature',
+  };
+
+  it('subject with default subject separator', () => {
+    const options = {};
+    expect(buildCommit(answers, options)).toEqual('feat(app): this is a new feature');
+  });
+
+  it('subject with custom subject separator option', () => {
+    const options = {
+      subjectSeparator: ' - ',
+    };
+    expect(buildCommit(answers, options)).toEqual('feat(app) - this is a new feature');
+  });
+
+  it('subject 1 empty character separator', () => {
+    const options = {
+      subjectSeparator: ' ',
+    };
+    expect(buildCommit(answers, options)).toEqual('feat(app) this is a new feature');
+  });
+
+  describe('without scope', () => {
+    it('subject without scope', () => {
+      const answersNoScope = {
+        type: 'feat',
+        subject: 'this is a new feature',
+      };
+      const options = {};
+      expect(buildCommit(answersNoScope, options)).toEqual('feat: this is a new feature');
+    });
+
+    it('subject without scope', () => {
+      const answersNoScope = {
+        type: 'feat',
+        subject: 'this is a new feature',
+      };
+      const options = {
+        subjectSeparator: ' - ',
+      };
+      expect(buildCommit(answersNoScope, options)).toEqual('feat - this is a new feature');
+    });
+  });
+
+  describe('type prefix and type suffix', () => {
+    it('subject with both', () => {
+      const answersNoScope = {
+        type: 'feat',
+        subject: 'this is a new feature',
+      };
+      const options = {
+        typePrefix: '[',
+        typeSuffix: ']',
+        subjectSeparator: ' ',
+      };
+      expect(buildCommit(answersNoScope, options)).toEqual('[feat] this is a new feature');
+    });
+  });
+});


### PR DESCRIPTION
* feat: add options `subjectSeparator`, `typePrefix` and `typeSuffix`

This will allow a lot more flexibility to construct any kind of commit message pattern. Examples:
* `feat(myScope): create a new cool feature`
* `feat(myScope) - create a new cool feature`
* `feat - create a new cool feature`
* `[feat] create a new cool feature`

* Added `lodash` dependency. We can now make use of `lodash` in any new code! 