### PR TITLE
feat: add configuration option upperCaseSubject

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Here are the options you can set in your `.cz-config.js`:
 * **breakingPrefix**: {string, default 'BREAKING CHANGE:'}: Set a custom prefix for the breaking change block in commit messages.
 * **footerPrefix**: {string, default 'ISSUES CLOSED:'}: Set a custom prefix for the footer block in commit messages. Set to empty string to remove prefix.
 * **breaklineChar**: {string, default '|'}: It gets replaced with \n to create the breakline in your commit message. This is supported for fields `body` and `footer` at the moment.
+* **upperCaseSubject**: { boolean, default false }: Capitalizes first subject letter if set to `true` 
 
 ## Related tools
 - (https://github.com/commitizen/cz-cli)

--- a/questions.js
+++ b/questions.js
@@ -117,7 +117,9 @@ module.exports = {
           return true;
         },
         filter(value) {
-          return value.charAt(0).toLowerCase() + value.slice(1);
+          const upperCaseSubject = config.upperCaseSubject || false;
+
+          return (upperCaseSubject ? value.charAt(0).toUpperCase() : value.charAt(0).toLowerCase()) + value.slice(1);
         },
       },
       {

--- a/spec/questionsSpec.js
+++ b/spec/questionsSpec.js
@@ -108,6 +108,19 @@ describe('cz-customizable', () => {
     ).toEqual('Exceed limit: 100');
   });
 
+  it('subject should be lowercased by default', () => {
+    config = {};
+    expect(getQuestion(5).filter('Some subject')).toEqual('some subject');
+  });
+
+  it('subject should be capitilized when config property "upperCaseSubject" is set to true', () => {
+    config = {
+      upperCaseSubject: true,
+    };
+
+    expect(getQuestion(5).filter('some subject')).toEqual('Some subject');
+  });
+
   describe('optional fixOverride and allowBreakingChanges', () => {
     it('should restrict BREAKING CHANGE question when config property "allowBreakingChanges" specifies array of types', () => {
       config = {


### PR DESCRIPTION
Adds `{ upperCaseSubject }` (default `false`) to configuration.

This follows the pattern:

| upperCaseSubject | Input Subject | Output Subject |
|:------------------:|:--------------:|:---------------:|
| `true`                     | `some subject`| `Some subject`|
| `false` (default)    | `Some subject`| `some subject`|