### PR TITLE
fix: `yes` should be default for confirmCommit

### DIFF
--- a/questions.js
+++ b/questions.js
@@ -153,6 +153,7 @@ module.exports = {
           { key: 'n', name: 'Abort commit', value: 'no' },
           { key: 'e', name: 'Edit message', value: 'edit' },
         ],
+        default: 0,
         message(answers) {
           const SEP = '###--------------------------------------------------------###';
           log.info(`\n${SEP}\n${buildCommit(answers, config)}\n${SEP}\n`);


### PR DESCRIPTION
We would like to use cz-customizable in our company and we think it makes sense to be able to press ENTER until the end, without any extra effort, until you've created the commit. Hence, we propose to make 'yes' the default option in confirmCommit