### PR TITLE
feat: add support for multiple tickets and prefix omission

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,12 @@ Here are the options you can set in your `.cz-config.js`:
 * **allowBreakingChanges**: {Array of Strings: default none}. List of commit types you would like to the question `breaking change` prompted. Eg.: ['feat', 'fix'].
 * **skipQuestions**: {Array of Strings: default none}. List of questions you want to skip. Eg.: ['body', 'footer'].
 * **appendBranchNameToCommitMessage**: If you use `cz-customizable` with `cz-customizable-ghooks`, you can get the branch name automatically appended to the commit message. This is done by a commit hook on `cz-customizable-ghooks`. This option has been added on `cz-customizable-ghooks`, v1.3.0. Default value is `true`.
+* **allowTicketNumber**: {string, default false}: Allow to optionally use tickets.
+* **isTicketNumberRequired**: {boolean, default false}: If true you have to provide ticket numbers.
 * **ticketNumberPrefix**: {string, default 'ISSUES CLOSED:'}: Set custom prefix for footer ticker number.
+* **ticketNumberRegExp**: {string, default ''}: Set regular expression to validate your tickets.
+* **ticketSeparator**: {string, default ','}: Set custom separator for multiple tickets.
+* **allowOmitTicketPrefix**: {string, default false}: Allow to omit ticket prefix in particular commits.
 * **breakingPrefix**: {string, default 'BREAKING CHANGE:'}: Set a custom prefix for the breaking change block in commit messages.
 * **footerPrefix**: {string, default 'ISSUES CLOSED:'}: Set a custom prefix for the footer block in commit messages. Set to empty string to remove prefix.
 * **breaklineChar**: {string, default '|'}: It gets replaced with \n to create the breakline in your commit message. This is supported for fields `body` and `footer` at the moment.

--- a/buildCommit.js
+++ b/buildCommit.js
@@ -4,15 +4,22 @@ const wrap = require('word-wrap');
 const defaultSubjectSeparator = ': ';
 const defaultMaxLineWidth = 100;
 const defaultBreaklineChar = '|';
+const defaultTicketSeparator = ',';
 
-const addTicketNumber = (ticketNumber, config) => {
-  if (!ticketNumber) {
+const addTicketNumber = (ticketNumbers, skipTicketPrefix, config) => {
+  if (!ticketNumbers) {
     return '';
   }
-  if (config.ticketNumberPrefix) {
-    return `${config.ticketNumberPrefix + ticketNumber.trim()} `;
+
+  const separator = _.get(config, 'ticketSeparator', defaultTicketSeparator);
+  let tickets = ticketNumbers.trim().split(separator);
+
+  let skipPrefix = skipTicketPrefix && skipTicketPrefix === 'yes';
+  if (config.ticketNumberPrefix && !skipPrefix) {
+      return `${tickets.map(n => config.ticketNumberPrefix.concat(n.trim())).join(', ')} `;
   }
-  return `${ticketNumber.trim()} `;
+
+  return `${tickets}`;
 };
 
 const addScope = (scope, config) => {
@@ -73,7 +80,7 @@ module.exports = (answers, config) => {
   const head = (
     addType(answers.type, config) +
     addScope(answers.scope, config) +
-    addTicketNumber(answers.ticketNumber, config) +
+    addTicketNumber(answers.ticketNumber, answers.skipTicketPrefix, config) +
     addSubject(answers.subject)
   ).slice(0, defaultMaxLineWidth);
 

--- a/cz-config-EXAMPLE.js
+++ b/cz-config-EXAMPLE.js
@@ -32,6 +32,8 @@ module.exports = {
   isTicketNumberRequired: false,
   ticketNumberPrefix: 'TICKET-',
   ticketNumberRegExp: '\\d{1,5}',
+  // ticketSeparator: ',', // default is comma
+  // allowOmitTicketPrefix: true, // default is false
 
   // it needs to match the value for field type. Eg.: 'fix'
   /*

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,17 +11,26 @@ declare module "cz-customizable" {
       type?: string,
       scope?: string,
       customScope?: string,
+      ticketNumber?: string,
+      omitTicketPrefix?: string,
       subject?: string,
       body?: string,
       breaking?: string,
       footer?: string,
       confirmCommit?: string,
     };
+
+    allowTicketNumber?: boolean;
+    isTicketNumberRequired?: boolean;
+    ticketNumberPrefix?: string;
+    ticketNumberRegExp?: string;
+    ticketSeparator?: string;
+    allowOmitTicketPrefix?: boolean;
+
     allowCustomScopes?: boolean;
     allowBreakingChanges?: string[];
     skipQuestions?: string[];
     appendBranchNameToCommitMessage?: boolean;
-    ticketNumberPrefix?: string;
     breakingPrefix?: string;
     footerPrefix?: string;
     subjectLimit?: number;

--- a/questions.js
+++ b/questions.js
@@ -11,9 +11,14 @@ const isValidateTicketNo = (value, config) => {
   if (!config.ticketNumberRegExp) {
     return true;
   }
+  const separator = _.get(config, 'ticketSeparator', ',');
+  let tickets = value.split(separator);
+
   const reg = new RegExp(config.ticketNumberRegExp);
-  if (value.replace(reg, '') !== '') {
-    return false;
+  for(v of tickets) {
+    if (v.trim().replace(reg, '') !== '') {
+      return false;
+    }
   }
   return true;
 };
@@ -32,11 +37,12 @@ module.exports = {
       if (config.ticketNumberRegExp) {
         messages.ticketNumber =
           messages.ticketNumberPattern ||
-          `Enter the ticket number following this pattern (${config.ticketNumberRegExp})\n`;
+          `Enter the ticket numbers following this pattern (${config.ticketNumberRegExp})\n`;
       } else {
-        messages.ticketNumber = 'Enter the ticket number:\n';
+        messages.ticketNumber = 'Enter the ticket numbers:\n';
       }
     }
+    messages.omitTicketPrefix = 'Do you want to omit ticket prefix?';
     messages.subject = messages.subject || 'Write a SHORT, IMPERATIVE tense description of the change:\n';
     messages.body =
       messages.body || 'Provide a LONGER description of the change (optional). Use "|" to break new line:\n';
@@ -104,6 +110,18 @@ module.exports = {
         },
         validate(value) {
           return isValidateTicketNo(value, config);
+        },
+      },
+      {
+        type: 'list',
+        name: 'omitTicketPrefix',
+        message: messages.omitTicketPrefix,
+        choices: ['no', 'yes'],
+        when() {
+          if(config.allowTicketNumber && config.ticketNumberPrefix && config.allowOmitTicketPrefix) {
+            return true;
+          }
+          return false;
         },
       },
       {


### PR DESCRIPTION
I've added the possibility to specify multiple tickets numbers and extended documentation a little bit. Also, you can omit ticket prefix for specific commits.

**Why do we need multiple commits**
Generally, it's a bad idea to link multiple issues with a single commit. However, there can be such cases where you need to do it. It's optionally, though.

**Why do we need to omit prefix?**
Because you can work with a forked repository and use their prefix as a default (e.g. leonardoanalista#issueN). However, sometimes you need to reference your own issues thus you need to omit prefix for a specific commit.

**Why do we need special support for it**
Because in the current implementation ticket prefix is prepended to the whole string and not to individual ticket number.

**Implementation**
If multiple tickets are specified using the configurable separator (`ticketSeparator`) they are split, checked for validity (if needed) and prepended with a prefix (if needed).
The prefix can be omitted for specific commits via command-line if option `allowOmitTicketPrefix` is specified.