### PR TITLE
refactor(edit): let git handle the edit instead of the custom impleme…

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,6 @@
 
 const CZ_CONFIG_NAME = '.cz-config.js';
 const findConfig = require('find-config');
-const editor = require('editor');
-const temp = require('temp').track();
-const fs = require('fs');
 const path = require('path');
 const log = require('./logger');
 const buildCommit = require('./buildCommit');
@@ -58,24 +55,7 @@ module.exports = {
 
     cz.prompt(questions).then(answers => {
       if (answers.confirmCommit === 'edit') {
-        temp.open(null, (err, info) => {
-          /* istanbul ignore else */
-          if (!err) {
-            fs.writeSync(info.fd, buildCommit(answers, config));
-            fs.close(info.fd, () => {
-              editor(info.path, code => {
-                if (code === 0) {
-                  const commitStr = fs.readFileSync(info.path, {
-                    encoding: 'utf8',
-                  });
-                  commit(commitStr);
-                } else {
-                  log.info(`Editor returned non zero value. Commit message was:\n${buildCommit(answers, config)}`);
-                }
-              });
-            });
-          }
-        });
+        commit(buildCommit(answers, config), { args: ['--edit'] });
       } else if (answers.confirmCommit === 'yes') {
         commit(buildCommit(answers, config));
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1401,7 +1401,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -1534,6 +1535,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1983,7 +1985,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -2480,11 +2483,6 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
-    },
-    "editor": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-      "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
     },
     "electron-to-chromium": {
       "version": "1.3.115",
@@ -3258,7 +3256,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -3764,6 +3763,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3772,7 +3772,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -4767,6 +4768,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -8522,6 +8524,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -8847,7 +8850,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -9652,6 +9656,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       },
@@ -9660,6 +9665,7 @@
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -10500,14 +10506,6 @@
         "through": "~2.3.4"
       }
     },
-    "temp": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz",
-      "integrity": "sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==",
-      "requires": {
-        "rimraf": "~2.6.2"
-      }
-    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -11093,7 +11091,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "editor": "1.0.0",
     "find-config": "^1.0.0",
     "inquirer": "^6.3.1",
     "lodash": "^4.17.11",
-    "temp": "^0.9.0",
     "word-wrap": "^1.2.3"
   },
   "devDependencies": {

--- a/spec/czCustomizableSpec.js
+++ b/spec/czCustomizableSpec.js
@@ -125,8 +125,6 @@ describe('cz-customizable', () => {
   });
 
   it('should allow edit message before commit', done => {
-    process.env.EDITOR = 'true';
-
     const answers = {
       confirmCommit: 'edit',
       type: 'feat',
@@ -137,25 +135,7 @@ describe('cz-customizable', () => {
     module.prompter(mockCz, commit);
 
     setTimeout(() => {
-      expect(commit).toHaveBeenCalledWith('feat: create a new cool feature');
-      done();
-    }, 100);
-  });
-
-  it('should not commit if editor returned non-zero value', done => {
-    process.env.EDITOR = 'false';
-
-    const answers = {
-      confirmCommit: 'edit',
-      type: 'feat',
-      subject: 'create a new cool feature',
-    };
-
-    const mockCz = getMockedCz(answers);
-    module.prompter(mockCz, commit);
-
-    setTimeout(() => {
-      expect(commit.wasCalled).toEqual(false);
+      expect(commit).toHaveBeenCalledWith('feat: create a new cool feature', { args: ['--edit'] });
       done();
     }, 100);
   });

--- a/standalone.js
+++ b/standalone.js
@@ -8,9 +8,11 @@ const log = require('./logger');
 
 log.info('cz-customizable standalone version');
 
-const commit = commitMessage => {
+const commit = (commitMessage, options) => {
   try {
-    execSync(`git commit -m "${commitMessage}"`, { stdio: [0, 1, 2] });
+    const args = [`commit`, `-m`, `"${commitMessage}"`, ...((options && options.args) || [])];
+    const argsString = args.toString().replace(/,/g, ' ');
+    execSync(`git ${argsString}`, { stdio: 'inherit' });
   } catch (error) {
     log.error('>>> ERROR', error.error);
   }


### PR DESCRIPTION
…ntation
Thoughts about this change: 
`editor` by default opens the `notepad` or `vim`, but there's scenarios: 
1. a linux machine without `vim`, 
2. the message format is not displayed correctly in `notepad`

so I think it's best to let `git` to handle all of the cases instead of the custom implemetation. 
