### PR TITLE
subjectLimit option usage and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Hopefully this will help you to have consistent commit messages and have a fully
 
 Here are the options you can set in your `.cz-config.js`:
 
-* **subjectLimit**: {number, default 100}: This is the commit first line. Example: `feat: this is a new feature` or `feat(scopePayments): this is a new feature`
+* **subjectLimit**: {number, default 100}: This is the subject limit. Example: `this is a new feature` or `fix a bug`
 * **subjectSeparator**: {string, default ': '}: This is the subject separator. Example: `feat: this is a new feature`
 * **typePrefix**: {string, default ''}: This is the commit type prefix. Example: config: `{ typePrefix: '[' }`, result: `[feat: this is a new feature`
 * **typeSuffix**: {string, default ''}: This is the commit type suffix. Example: config: `{ typePrefix: '[', typeSuffix: ']', subjectSeparator: ' ' }`, result: `[feat] this is a new feature`

--- a/buildCommit.js
+++ b/buildCommit.js
@@ -75,7 +75,7 @@ module.exports = (answers, config) => {
     addScope(answers.scope, config) +
     addTicketNumber(answers.ticketNumber, config) +
     addSubject(answers.subject)
-  ).slice(0, defaultMaxLineWidth);
+  ).slice(0, config.subjectLimit);
 
   // Wrap these lines at 100 characters
   let body = wrap(answers.body, wrapOptions) || '';

--- a/buildCommit.js
+++ b/buildCommit.js
@@ -70,12 +70,11 @@ module.exports = (answers, config) => {
 
   // Hard limit this line
   // eslint-disable-next-line max-len
-  const head = (
+  const head =
     addType(answers.type, config) +
     addScope(answers.scope, config) +
     addTicketNumber(answers.ticketNumber, config) +
-    addSubject(answers.subject)
-  ).slice(0, config.subjectLimit);
+    addSubject(answers.subject.slice(0, config.subjectLimit));
 
   // Wrap these lines at 100 characters
   let body = wrap(answers.body, wrapOptions) || '';

--- a/index.js
+++ b/index.js
@@ -48,10 +48,11 @@ const readConfigFile = () => {
 module.exports = {
   prompter(cz, commit) {
     const config = readConfigFile();
-    const subjectLimit = config.subjectLimit || 100;
-
+    config.subjectLimit = config.subjectLimit || 100;
     log.info(
-      `\n\nLine 1 will be cropped at ${subjectLimit} characters. All other lines will be wrapped after 100 characters.\n`
+      `\n\nLine 1 will be cropped at
+      ${config.subjectLimit}
+      characters. All other lines will be wrapped after 100 characters.\n`
     );
 
     const questions = require('./questions').getQuestions(config, cz);

--- a/index.js
+++ b/index.js
@@ -49,11 +49,7 @@ module.exports = {
   prompter(cz, commit) {
     const config = readConfigFile();
     config.subjectLimit = config.subjectLimit || 100;
-    log.info(
-      `\n\nLine 1 will be cropped at
-      ${config.subjectLimit}
-      characters. All other lines will be wrapped after 100 characters.\n`
-    );
+    log.info('All lines except first will be wrapped after 100 characters.');
 
     const questions = require('./questions').getQuestions(config, cz);
 

--- a/spec/czCustomizableSpec.js
+++ b/spec/czCustomizableSpec.js
@@ -160,7 +160,7 @@ describe('cz-customizable', () => {
     }, 100);
   });
 
-  it('should truncate first line if number of characters is higher than 100', () => {
+  it('should truncate subject if number of characters is higher than 100', () => {
     const chars100 =
       '0123456789-0123456789-0123456789-0123456789-0123456789-0123456789-0123456789-0123456789-0123456789-0123456789';
 
@@ -183,7 +183,7 @@ describe('cz-customizable', () => {
     const firstPart = 'feat(myScope): ';
 
     const firstLine = commit.mostRecentCall.args[0].split('\n\n')[0];
-    expect(firstLine).toEqual(firstPart + answers.subject.slice(0, 100 - firstPart.length));
+    expect(firstLine).toEqual(firstPart + answers.subject.slice(0, 100));
 
     // it should wrap body
     const body = commit.mostRecentCall.args[0].split('\n\n')[1];

--- a/spec/czCustomizableSpec.js
+++ b/spec/czCustomizableSpec.js
@@ -160,7 +160,7 @@ describe('cz-customizable', () => {
     }, 100);
   });
 
-  it('should truncate first line if number of characters is higher than 200', () => {
+  it('should truncate first line if number of characters is higher than 100', () => {
     const chars100 =
       '0123456789-0123456789-0123456789-0123456789-0123456789-0123456789-0123456789-0123456789-0123456789-0123456789';
 

--- a/spec/questionsSpec.js
+++ b/spec/questionsSpec.js
@@ -26,7 +26,7 @@ describe('cz-customizable', () => {
       isTicketNumberRequired: true,
       ticketNumberPrefix: 'TICKET-',
       ticketNumberRegExp: '\\d{1,5}',
-      subjectLimit: 20,
+      subjectLimit: 40,
     };
 
     // question 1 - TYPE
@@ -64,7 +64,7 @@ describe('cz-customizable', () => {
     expect(getQuestion(5).type).toEqual('input');
     expect(getQuestion(5).message).toMatch(/IMPERATIVE tense description/);
     expect(getQuestion(5).filter('Subject')).toEqual('subject');
-    expect(getQuestion(5).validate('bad subject that exceed limit')).toEqual('Exceed limit: 20');
+    expect(getQuestion(5).validate('bad subject that exceed limit for 6 characters')).toEqual('Exceed limit: 40');
     expect(getQuestion(5).validate('good subject')).toEqual(true);
 
     // question 6 - BODY


### PR DESCRIPTION
Current changes solve next problems:

1. subjectLimit property overrides by defaultMaxLineWidth.
2. Subject message validates by subjectLimit property, but when it trims, include prefix and scope – trim does not correct.