### PR TITLE
docs: mention possible alternative path for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Use `cz-customizable` without `commitzen`.
 
 ### Option 1 - You can make changes to your git repository, file `package.json`.
 
-* `cz-customizable` will first look for a file called `.cz-config.js` in the project root, near your `package.json`
-* If no config found, it will look for `.cz-config.js` your home directory
+* `cz-customizable` will first look for a file called `.cz-config.js` or `.config/cz-config.js` in the project root, near your `package.json`
+* If no config found, it will look for `.cz-config.js` or or `.config/cz-config.js` in your home directory
 * alternatively add the config location in your `package.json`:
 ```
 ...


### PR DESCRIPTION
A lot of people prefer using a `.config` folder to limit the number of files at the root of their repository.

Good news! *cz-customizable* uses [find-config](https://www.npmjs.com/package/find-config) which looks up for both `.cz-config.js` and `.config/cz-config.js`.

This PR is to mention it in the docs! 